### PR TITLE
Make kivy-designer handle windows paths correctly.  

### DIFF
--- a/designer/project_loader.py
+++ b/designer/project_loader.py
@@ -1011,7 +1011,7 @@ class ProjectLoader(object):
             sys.modules['AppModule'] = module
             return module
 
-        module_name = _file[_file.rfind('/')+1:].replace('.py', '')
+        module_name = _file[_file.rfind(os.sep)+1:].replace('.py', '')
         if module_name in sys.modules:
             del sys.modules[module_name]
 


### PR DESCRIPTION
Fixes thowing "Import by filename is not supported" error when new project is created.  This appear to fix issue #27 on windows machines.

Don't have a linux environment handy and would appreciate feedback if it breaks anything on linux
