### PR TITLE
[FIX] Several ImportErrors because untracked dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+kivy >= 1.8
+pygments
+docutils


### PR DESCRIPTION
Is a de-facto standard to have a pip-able requirements.txt with the project dependencies.

TODO: Update the documentation with instructions
