### PR TITLE
Added missing watchdog dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 kivy >= 1.8
 pygments
 docutils
+watchdog


### PR DESCRIPTION
kivy-designer won't run without watchdog.
