### PR TITLE
Fix command line to use kivy instead of python

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ With the prequisites installed, you can use the designer:
     
     git clone http://github.com/kivy/kivy-designer/
     cd kivy-designer
-    python main.py
+    kivy main.py
 
 
 ![ScreenShot](https://raw.github.com/kivy/kivy-designer/master/kivy_designer.png)


### PR DESCRIPTION
Using official Kivy 1.8.0 on OSX,
attempting to run ‘python main.py’ results in the following error:
 ImportError: cannot import name actionbar

Running ‘kivy main.py’ works just fine.
