### PR TITLE
speed fixes

### DIFF
--- a/designer/propertyviewer.py
+++ b/designer/propertyviewer.py
@@ -168,6 +168,10 @@ class PropertyViewer(ScrollView):
        :data:`kv_code_input` is a :class:`~kivy.properties.ObjectProperty`
     '''
 
+    def __init__(self, **kwargs):
+        super(PropertyViewer, self).__init__(**kwargs)
+        self._label_cache = {}
+
     def on_widget(self, instance, value):
         '''Default handler for 'on_widget'.
         '''
@@ -189,14 +193,22 @@ class PropertyViewer(ScrollView):
         '''
 
         add = self.prop_list.add_widget
+        get_label = self._get_label
         props = value.properties().keys()
         props.sort()
         for prop in props:
             ip = self.build_for(prop)
             if not ip:
                 continue
-            add(PropertyLabel(text=prop))
+            add(get_label(prop))
             add(ip)
+
+    def _get_label(self, prop):
+        try:
+            return self._label_cache[prop]
+        except KeyError:
+            lbl = self._label_cache[prop] = PropertyLabel(text=prop)
+            return lbl
 
     def build_for(self, name):
         '''To create :class:`~designer.propertyviewer.PropertyBoolean`

--- a/designer/statusbar.py
+++ b/designer/statusbar.py
@@ -1,4 +1,5 @@
 from kivy.properties import ObjectProperty
+from kivy.clock import Clock
 from kivy.uix.button import Button
 from kivy.uix.label import Label
 from kivy.uix.boxlayout import BoxLayout
@@ -55,6 +56,10 @@ class StatusBar(BoxLayout):
        :class:`~kivy.properties.ObjectProperty`
     '''
 
+    def __init__(self, **kwargs):
+        super(StatusBar, self).__init__(**kwargs)
+        self.update_navbar = Clock.create_trigger(self._update_navbar)
+
     def show_message(self, message):
         '''To show a message in StatusBar
         '''
@@ -74,7 +79,7 @@ class StatusBar(BoxLayout):
     def on_app(self, instance, app):
         app.bind(widget_focused=self.update_navbar)
 
-    def update_navbar(self, *largs):
+    def _update_navbar(self, *largs):
         '''To update navbar with the parents of currently selected Widget.
         '''
 


### PR DESCRIPTION
1. Create triggers for some update functions to ensure they are never called more than once per frame.
2. Cache tree items in `WidgetsTree` - the tree data will rarely change a significant amount, but currently all of the tree widgets are thrown away and recreated constantly. Instead, we can reuse these widgets.
3. Cache labels in `PropertyViewer` - especially handy since many of these labels are common to every widget.
