### PR TITLE
handle dead proxy refs in nodetree cache

### DIFF
--- a/designer/nodetree.py
+++ b/designer/nodetree.py
@@ -114,8 +114,12 @@ class WidgetsTree(ScrollView):
     
     def _clean_cache(self):
         for node, wid in self._widget_cache.items():
-            if not node or not node.parent or not wid or not wid.parent_node:
-                del self._widget_cache[node]
+            try:
+                if node and node.parent and wid and wid.parent_node:
+                    continue
+            except ReferenceError:
+                pass
+            del self._widget_cache[node]
 
     def on_touch_up(self, touch):
         '''Default event handler for 'on_touch_up' event.


### PR DESCRIPTION
I had thought that `not wid` would handle dead references, as `wid` seemingly becomes a proxy to `NoneType`, but in fact `not wid` raises `ReferenceError`!!

```
ipdb> wid
<weakproxy at 0x7f3c35b35158 to NoneType at 0x920190>
ipdb> wid.parent_node
*** ReferenceError: weakly-referenced object no longer exists
ipdb> not wid
*** ReferenceError: weakly-referenced object no longer exists
```
