### PR TITLE
make PlaygroundDragElement move search recursively for target

### DIFF
--- a/designer/playground.py
+++ b/designer/playground.py
@@ -33,8 +33,10 @@ from designer.uix.designer_sandbox import DesignerSandbox
 def widget_contains(container, child):
     '''Search recursively for child in container
     '''
+    if container == child:
+        return True
     for w in container.children:
-        if w == child or widget_contains(w, child):
+        if widget_contains(w, child):
             return True
     return False
 
@@ -205,7 +207,7 @@ class PlaygroundDragElement(BoxLayout):
 
                                     node = node.parent_node
 
-                if target == self.child or widget_contains(self.child, target):
+                if widget_contains(self.child, target):
                     return True
 
                 if self.child.parent:


### PR DESCRIPTION
Making my own custom widgets, I ran into an issue with `PlaygroundDragElement` trying to add a complex widget to one if its own children.

Example - add the following to `designer/common.py`:

```
widgets = [
    ...
    ('TabbedPanelTest', 'complex'),
 ]

from kivy.lang import Builder
Builder.load_string('''
<TabbedPanelTest@TabbedPanel>:
    do_default_tab: False
    TabbedPanelItem:
        GridLayout:
''')
```

Create a new project (I tested with the `BoxLayout` template), then add the `TabbedPanelTest` to the project. When you drag the `TabbedPanelTest` over the `BoxLayout` it will be added. Keep dragging the `PlaygroundDragElement` over the nested `GridLayout` and the `TabbedPanelTest` will then be added to its own `GridLayout`, causing the interpreter stack to blow up from an infinite loop attempting to process the graphics instructions.
