### PR TITLE
Can now view Buildozer (spec) files

### DIFF
--- a/designer/app.py
+++ b/designer/app.py
@@ -597,7 +597,7 @@ class Designer(FloatLayout):
         except:
             error = 'Cannot load empty file type'
     
-        self.statusbar.show_message(error)
+            self.statusbar.show_message(error)
                 
 
     def _perform_open(self, file_path):

--- a/designer/app.py
+++ b/designer/app.py
@@ -586,19 +586,20 @@ class Designer(FloatLayout):
 
         file_path = instance.selection[0]
         file_extension = instance.selection[0].split('.')
-        
+
         self._popup.dismiss()
+        error = None
         try:
             if file_extension[1] == 'py':
                 self._perform_open(file_path)
-            else: 
+            else:
                 error = 'Cannot load file type: .%s, Please load a .py file' % \
                     (file_extension[1])
         except:
             error = 'Cannot load empty file type'
-    
+
+        if error:
             self.statusbar.show_message(error)
-                
 
     def _perform_open(self, file_path):
         '''To open a project given by file_path

--- a/designer/designer_content.py
+++ b/designer/designer_content.py
@@ -100,11 +100,10 @@ class DesignerContent(FloatLayout):
                     break
 
             if not found:
-                # Weird path mixup when reloading project from dir changes
-                # for component in list_path_components:
-                #     _node = TreeViewLabel(text=component)
-                #     self.tree_view.add_node(_node, node)
-                #     node = _node
+                for component in list_path_components:
+                    _node = TreeViewLabel(text=component)
+                    self.tree_view.add_node(_node, node)
+                    node = _node
                 list_path_components = []
             else:
                 del list_path_components[0]

--- a/designer/designer_content.py
+++ b/designer/designer_content.py
@@ -100,10 +100,11 @@ class DesignerContent(FloatLayout):
                     break
 
             if not found:
-                for component in list_path_components:
-                    _node = TreeViewLabel(text=component)
-                    self.tree_view.add_node(_node, node)
-                    node = _node
+                # Weird path mixup when reloading project from dir changes
+                # for component in list_path_components:
+                #     _node = TreeViewLabel(text=component)
+                #     self.tree_view.add_node(_node, node)
+                #     node = _node
                 list_path_components = []
             else:
                 del list_path_components[0]

--- a/designer/project_loader.py
+++ b/designer/project_loader.py
@@ -113,8 +113,8 @@ class ProjectLoader(object):
             if os.path.isdir(file_path):
                 file_list += self._get_file_list(file_path)
             else:
-                #Consider only kv and py files
-                if file_path[file_path.rfind('.'):] == '.py':
+                # Consider only kv, py and buildozer(spec) files
+                if file_path[file_path.rfind('.'):] in [".py", ".spec"]:
                     if os.path.dirname(file_path) == self.proj_dir:
                         file_list.insert(0, file_path)
                     else:

--- a/designer/project_loader.py
+++ b/designer/project_loader.py
@@ -636,7 +636,6 @@ class ProjectLoader(object):
                     f = open(_rule.file, 'r')
                     s = f.read()
                     f.close()
-
                     self._import_module(s, _rule.file, _fromlist=[_rule.name])
 
                 relative_path = self.root_rule.kv_file[
@@ -676,7 +675,9 @@ class ProjectLoader(object):
                 if self.root_rule.file == path:
                     _from_list.append(self.root_rule.name)
 
-            self._import_module(_code_input.text, path, _fromlist=_from_list)
+            if path.endswith(".py"):
+                self._import_module(_code_input.text, path,
+                                    _fromlist=_from_list)
 
         #Save all class rules
         text = self.kv_code_input.text

--- a/designer/project_loader.py
+++ b/designer/project_loader.py
@@ -675,6 +675,7 @@ class ProjectLoader(object):
                 if self.root_rule.file == path:
                     _from_list.append(self.root_rule.name)
 
+            # Ignore all types that are not .py
             if path.endswith(".py"):
                 self._import_module(_code_input.text, path,
                                     _fromlist=_from_list)


### PR DESCRIPTION
Kivy Designer is able to open buildozer(.spec) files, and display them along with the .py files. Problem is that when trying to save a project that has added a .spec file, the status bar says it fails, even though it did successfully save. Also when changing the proj dir from outside, and reloading it from designer, causes a fatal error when trying to open any file. From what I am able to see the problem was that it tried to cancat the proj path with the files path. 
For example:  
proj_dir = "/home/me/"
file = "/home/me/file.py"
Disigner would basically try to open this:
"/home/me//home/me/file.py" (proj_dir + file)

I solved this by commenting out the lines on designer/designer_content.py 