### PR TITLE
Initial buildozer integration

### DIFF
--- a/config.ini
+++ b/config.ini
@@ -1,5 +1,7 @@
 [global]
 python_shell_path = 
+buildozer_path =
+create_buildozer_prj = True
 reload_kv = True
 num_recent_files = 5
 auto_save_time = 5

--- a/designer/app.py
+++ b/designer/app.py
@@ -6,6 +6,7 @@ import os
 import shutil
 import traceback
 import subprocess
+import distutils.spawn
 
 kivy.require('1.8.0')
 from kivy.app import App
@@ -460,15 +461,15 @@ class Designer(FloatLayout):
             has_error = None
             if len(buildozer_path) == 0:
                 if buildozer_path == "": #try to find buildozer in the first execution if its not configured
-                    self.config_parser.set('global', 'buildozer_path',
-                                        find_executable('buildozer'))
-                    self.config_parser.write()
+                    self.designer_settings.config_parser.set('global', 'buildozer_path',
+                                        distutils.spawn.find_executable('buildozer'))
+                    self.designer_settings.config_parser.write()
                     buildozer_path = self.designer_settings.config_parser.getdefault(
                                             'global', 'buildozer_path', '')
 
             if len(buildozer_path) > 0: #if buildozer is configured
                 try:
-                    subprocess.call([buildozer_path+"awe", "init"], cwd=new_proj_dir)
+                    subprocess.call([buildozer_path, "init"], cwd=new_proj_dir)
                 except OSError:
                     has_error = "Cannot run buildozer. Check if the path is correct."
                 except Exception as e:
@@ -478,6 +479,7 @@ class Designer(FloatLayout):
 
             if has_error:
                 self.error_dialog = BuildozerErrorDialog()
+                self.error_dialog.ids.txt.text = "Error while trying to create buildozer.spec file. \nError message:" + has_error
                 self.buildozer_popup = Popup(title="Error with Buildozer",
                             content=self.error_dialog,
                             size_hint=(.5, .5),

--- a/designer/designer.kv
+++ b/designer/designer.kv
@@ -57,6 +57,17 @@
         size: '44pt', '22pt'
         on_release: root.dispatch('on_cancel')
 
+<BuildozerErrorDialog>:
+    Label:
+        text: 'Kivy Designer'
+        id: txt
+        
+    Button:
+        text: 'Close'
+        size_hint: None, None
+        size: '44pt', '22pt'
+        on_release: root.dispatch('on_cancel')
+
 
 <MenuHeader>
     color: (1, 1, 1, 1) if self.state == 'normal' else (0, 0, 0, 1)

--- a/designer/designer_settings.py
+++ b/designer/designer_settings.py
@@ -2,7 +2,7 @@ import os
 import os.path
 import shutil
 import sys
-
+from distutils.spawn import find_executable
 from kivy.properties import ObjectProperty
 from kivy.config import ConfigParser
 from kivy.uix.settings import Settings, SettingTitle
@@ -69,6 +69,14 @@ class DesignerSettings(Settings):
         if path == "":
             self.config_parser.set('global', 'python_shell_path',
                                    sys.executable)
+            self.config_parser.write()
+
+        buildozer_path = self.config_parser.getdefault(
+            'global', 'buildozer_path', '')
+
+        if buildozer_path == "":
+            self.config_parser.set('global', 'buildozer_path',
+                                        find_executable('buildozer'))
             self.config_parser.write()
 
     def on_config_change(self, *args):

--- a/designer/designer_settings.py
+++ b/designer/designer_settings.py
@@ -60,8 +60,6 @@ class DesignerSettings(Settings):
 
         self.config_parser.read(DESIGNER_CONFIG)
         self.config_parser.upgrade(DEFAULT_CONFIG)
-        self.add_json_panel('Kivy Designer Settings', self.config_parser,
-                            os.path.join(_dir, 'designer', 'settings', 'designer_settings.json'))
 
         path = self.config_parser.getdefault(
             'global', 'python_shell_path', '')
@@ -78,6 +76,9 @@ class DesignerSettings(Settings):
             self.config_parser.set('global', 'buildozer_path',
                                         find_executable('buildozer'))
             self.config_parser.write()
+
+        self.add_json_panel('Kivy Designer Settings', self.config_parser,
+                            os.path.join(_dir, 'designer', 'settings', 'designer_settings.json'))
 
     def on_config_change(self, *args):
         '''This function is default handler of on_config_change event.

--- a/designer/designer_settings.py
+++ b/designer/designer_settings.py
@@ -3,6 +3,7 @@ import os.path
 import shutil
 import sys
 from distutils.spawn import find_executable
+
 from kivy.properties import ObjectProperty
 from kivy.config import ConfigParser
 from kivy.uix.settings import Settings, SettingTitle

--- a/designer/help_dialog.py
+++ b/designer/help_dialog.py
@@ -31,3 +31,16 @@ class AboutDialog(BoxLayout):
         '''Default handler for 'on_cancel' event
         '''
         pass
+
+
+class BuildozerErrorDialog(BoxLayout):
+    '''BuildozerErrorDialog, to display any error while creating a buildozer.spec file.
+       It emits 'on_cancel' event when 'Cancel' button is released.
+    '''
+
+    __events__ = ('on_cancel',)
+
+    def on_cancel(self, *args):
+        '''Default handler for 'on_cancel' event
+        '''
+        pass

--- a/designer/settings/designer_settings.json
+++ b/designer/settings/designer_settings.json
@@ -6,6 +6,18 @@
         "key": "python_shell_path"
     },
     {
+        "type": "string",
+        "title": "Buildozer Path",
+        "section": "global",
+        "key": "buildozer_path"
+    },
+    {
+        "type": "bool",
+        "title": "Create buildozer.spec Automatically",
+        "section": "global",
+        "key": "create_buildozer_prj"
+    },
+    {
         "type": "bool",
         "title": "Reload KV Automatically",
         "section": "global",


### PR DESCRIPTION
Buildozer integrated with Kivy Designer. 
When the Kivy-designer start, it'll try to find buildozer and save the path in the settings. 
It's also possible to edit the path and enable buildozer to auto create the buildozer.spec file with the project. 

Settings screen:

![screenshot from 2015-03-24 16 53 50](https://cloud.githubusercontent.com/assets/4960137/6811483/09828f44-d247-11e4-9b07-11a96087ea4c.png)

buildozer.spec auto created:
![screenshot from 2015-03-24 16 54 14](https://cloud.githubusercontent.com/assets/4960137/6811495/1ef72f42-d247-11e4-820e-401377b2b52a.png)

If get some error while trying to start a new project, will show an alert.
![screenshot from 2015-03-24 17 00 11](https://cloud.githubusercontent.com/assets/4960137/6811516/4698355a-d247-11e4-9fff-85f44b25b0fd.png)
