### PR TITLE
Bug reporter

### DIFF
--- a/designer/uix/bug_reporter.py
+++ b/designer/uix/bug_reporter.py
@@ -1,0 +1,98 @@
+from kivy.lang import Builder
+from kivy.properties import ObjectProperty
+from kivy.app import App
+from kivy.uix.floatlayout import FloatLayout
+from kivy.core.clipboard import Clipboard
+import webbrowser
+import six.moves.urllib
+
+
+Builder.load_string('''
+<BugReporter>:
+    txt_traceback: txt_traceback
+    Image:
+        source: 'data/logo/kivy-icon-256.png'
+        opacity: 0.2
+    BoxLayout:
+        orientation: 'vertical'
+        padding: 10
+        Label:
+            id: title
+            text: 'Sorry, Kivy Designer has experienced an internal error :('
+            font_size: '16pt'
+            halign: 'center'
+            size_hint_y: None
+            height: '30pt'
+        Label:
+            id: subtitle
+            text: 'You can report this bug using the button bellow, ' \
+                    'helping us to fix it.'
+            text_size: self.size
+            font_size: '11pt'
+            halign: 'center'
+            valign: 'top'
+            size_hint_y: None
+            height: '30pt'
+        ScrollView:
+            id: e_scroll
+            bar_width: 10
+            scroll_y: 0
+            TextInput:
+                id: txt_traceback
+                size_hint_y: None
+                height: max(e_scroll.height, self.minimum_height)
+                background_color: 1, 1, 1, 0.05
+                text: ''
+                foreground_color: 1, 1, 1, 1
+                readonly: True
+        BoxLayout:
+            size_hint: 0.5, None
+            padding: 10, 10
+            height: 50
+            pos_hint: {'x':0.25}
+            spacing: 5
+            Button:
+                text: 'Copy to clipboard'
+                on_press: root.on_clipboard()
+            Button:
+                text: 'Report Bug'
+                on_press: root.on_report()
+''')
+
+
+class BugReporter(FloatLayout):
+    txt_traceback = ObjectProperty(None)
+    '''TextView to show the traceback message
+    '''
+
+    def on_clipboard(self, *args):
+        '''Event handler to "Copy to Clipboard" button
+        '''
+        Clipboard.copy(self.txt_traceback.text)
+
+    def on_report(self, *args):
+        '''Event handler to "Report Bug" button
+        '''
+        txt = six.moves.urllib.parse.quote(self.txt_traceback.text)
+        url = 'https://github.com/kivy/kivy-designer/issues/new?body=' + txt
+        webbrowser.open(url)
+
+
+class BugReporterApp(App):
+
+    title = "Kivy Designer - Bug reporter"
+    traceback = ''
+
+    def __init__(self, traceback):
+        self.traceback = traceback
+        super(BugReporterApp, self).__init__()
+
+    def build(self):
+        rep = BugReporter()
+        rep.txt_traceback.text = self.traceback
+
+        return rep
+
+
+if __name__ == '__main__':
+    BugReporterApp('Bug example').run()

--- a/main.py
+++ b/main.py
@@ -1,3 +1,12 @@
+import traceback
+from kivy.core.window import Window
+from designer.app import DesignerApp
+from designer.uix.bug_reporter import BugReporterApp
+
 if __name__ == '__main__':
-    from designer.app import DesignerApp
-    DesignerApp().run()
+    try:
+        DesignerApp().run()
+    except Exception as e:
+        for child in Window.children:
+            Window.remove_widget(child)
+        BugReporterApp(traceback.format_exc()).run()


### PR DESCRIPTION
As long as Kivy Designer is an IDE under development, would be great to alert to users about our bugs and mainly to get a feedback from them. So I created a Bug reporter, it's something basic, but I believe that this feature can help us to find more bugs. 

The entire app is running in a try catch, is some exception occurs, this window will be visible, with the possibility to copy the copy the traceback to the clipboard or to open a new issue on Github. 

![screenshot from 2015-05-30 00-15-33](https://cloud.githubusercontent.com/assets/4960137/7895419/d67dc712-0662-11e5-8415-fb83e636ca29.png)


Issues:
https://github.com/aron-bordin/kivy-designer/issues/79