### PR TITLE
Build profile

### DIFF
--- a/config.ini
+++ b/config.ini
@@ -18,6 +18,7 @@ exit_on_escape = 0
 [internal]
 window_width = 800
 window_height = 600
+default_profile =
 
 [view]
 actn_chk_proj_tree = True

--- a/designer/app.py
+++ b/designer/app.py
@@ -941,10 +941,10 @@ class Designer(FloatLayout):
         self.prof_settings.load_profiles()
         self.fill_select_profile_menu()
 
-    def _perform_use_this_prof(self, *args):
+    def _perform_use_this_prof(self, instance, *args):
         '''Callback to "Use this Profile" button
         '''
-        _config = args[0].selected_config
+        _config = instance.selected_config
         _config_path = _config.filename
         self.designer_settings.config_parser.set('internal',
                                                 'default_profile',
@@ -981,12 +981,12 @@ class Designer(FloatLayout):
 
         prof_menu._add_widget()
 
-    def _perform_profile_selected(self, *args):
+    def _perform_profile_selected(self, instance, item, value, *args):
         '''Event handler to select profile radio button.
         Save the selected config_parser path to the config
         '''
-        if args[2]:
-            _config = self.prof_settings.config_parsers[args[0].config_key]
+        if value:
+            _config = self.prof_settings.config_parsers[instance.config_key]
             _config_path = _config.filename
             self.designer_settings.config_parser.set('internal',
                                                      'default_profile',

--- a/designer/designer.kv
+++ b/designer/designer.kv
@@ -128,6 +128,91 @@
         size: '44pt', '22pt'
         on_release: root.dispatch('on_cancel')
 
+#
+# Profile Settings
+#
+
+<ProfileSettings>:
+    interface_cls: 'ProfileSettingsInterface'
+
+<-ProfileSettingsInterface>:
+    orientation: 'horizontal'
+    menu: menu
+    content: content
+    button_bar: button_bar
+    ProfileMenuSidebar:
+        id: menu
+    GridLayout:
+        id: button_bar
+        btn_delete_prof: btn_delete_prof
+        btn_select_prof: btn_select_prof
+        cols: 1
+        GridLayout:
+            cols: 2
+            size_hint_y: None
+            height: 50
+            spacing: 5
+            padding: 5
+            Button:
+                id: btn_select_prof
+                text: 'Use this Profile'
+                size_hint: 0.5, None
+                height: 40
+            Button:
+                id: btn_delete_prof
+                disabled: True
+                text: 'Delete Profile'
+                size_hint: 0.5, None
+                height: 40
+        ProfileContentPanel:
+            id: content
+            current_uid: menu.selected_uid
+
+<-ProfileMenuSidebar>:
+    size_hint_x: None
+    width: '200dp'
+    buttons_layout: menu
+    close_button: button_close
+    new_button: button_new
+    ScrollView:
+        id: e_scroll
+        y: root.y + 70
+        x: root.x
+        width: root.width
+        size_hint_y: None
+        height: root.height - 75
+        GridLayout:
+            size_hint_y: None
+            height: max(e_scroll.height, self.minimum_height)
+            cols: 1
+            id: menu
+            orientation: 'vertical'
+            padding: 5
+            spacing: 5
+            canvas.after:
+                Color:
+                    rgb: .2, .2, .2
+                Rectangle:
+                    pos: self.right - 1, self.y
+                    size: 1, self.height
+    Button:
+        text: 'New'
+        id: button_new
+        size_hint: None, None
+        width: root.width - dp(20)
+        height: 30
+        pos: root.x + dp(10), root.y + 40
+        font_size: '15sp'
+    Button:
+        text: 'Close'
+        id: button_close
+        size_hint: None, None
+        width: root.width - dp(20)
+        height: 30
+        pos: root.x + dp(10), root.y + 5
+        font_size: '15sp'
+
+<ProfileContentPanel>:
 
 <MenuHeader>
     color: (1, 1, 1, 1) if self.state == 'normal' else (0, 0, 0, 1)

--- a/designer/designer.kv
+++ b/designer/designer.kv
@@ -1239,6 +1239,7 @@
                     id: select_profile_cont_menu
                     text: 'Select Profile'
                     on_release: root.action_btn_select_prof_project_pressed()
+                    show_arrow: True
                 DesignerActionButton:
                     id: actn_btn_edit_prof_proj
                     text: 'Edit Profiles...'

--- a/designer/profile_settings.py
+++ b/designer/profile_settings.py
@@ -174,12 +174,13 @@ class ProfileSettings(Settings):
         first_panel = self.interface.menu.buttons_layout.children[-1].uid
         self.interface.content.current_uid = first_panel
 
-    def on_config_change(self, *args):
+    def on_config_change(self, instance, section, key, value, *args):
         '''This function is default handler of on_config_change event.
         '''
-        args[0].write()
-        super(ProfileSettings, self).on_config_change(*args)
-        if args[2] == 'name':
+        super(ProfileSettings, self).on_config_change(
+            instance, section, key, value
+        )
+        if key == 'name':
             self.update_panel()
             self.settings_changed = True
 

--- a/designer/profile_settings.py
+++ b/designer/profile_settings.py
@@ -1,0 +1,256 @@
+import os
+import os.path
+import shutil
+
+from kivy.config import ConfigParser
+from kivy.properties import ObjectProperty, DictProperty
+from kivy.uix.popup import Popup
+from kivy.uix.settings import Settings, InterfaceWithSidebar, \
+    MenuSidebar, ContentPanel
+
+import designer
+from designer.confirmation_dialog import ConfirmationDialog
+from designer.helper_functions import get_kivy_designer_dir
+
+
+class ProfileContentPanel(ContentPanel):
+    ''' ContentPanel with a custom design and custom events
+    '''
+
+    __events__ = ('on_current_panel', )
+
+    def __int__(self, **kwargs):
+        super(ProfileContentPanel, self).__init__(**kwargs)
+
+    def on_current_uid(self, *args):
+        ''' Override the on_current_uid to to bind panel_change event
+        '''
+        super(ProfileContentPanel, self).on_current_uid(args)
+        self.dispatch('on_current_panel')
+
+    def on_current_panel(self, *args):
+        ''' Event handler for panel_change
+        '''
+        pass
+
+
+class ProfileMenuSidebar(MenuSidebar):
+    pass
+
+
+class ProfileSettingsInterface(InterfaceWithSidebar):
+    ''' InterfaceWithSidebar with a custom style and custom events
+    '''
+
+    button_bar = ObjectProperty(None)
+    ''' Reference to the widget's GridLayout with buttons
+    :class:`~kivy.properties.ObjectProperty` and defaults to None.
+    '''
+
+    new_button = ObjectProperty(None)
+    ''' Reference to the widget's New button.
+    :class:`~kivy.properties.ObjectProperty` and defaults to None.
+    '''
+
+    select_prof_button = ObjectProperty(None)
+    ''' Reference to the widget's Use this Profile button.
+    :class:`~kivy.properties.ObjectProperty` and defaults to None.
+    '''
+
+    __events__ = ('on_delete', 'on_new', 'on_use_this_profile')
+
+    def __init__(self, **kwargs):
+        super(ProfileSettingsInterface, self).__init__(**kwargs)
+        self.button_bar.btn_delete_prof.bind(
+            on_press=lambda j: self.dispatch('on_delete'))
+        self.button_bar.btn_select_prof.bind(
+            on_press=lambda j: self.dispatch('on_use_this_profile'))
+        self.menu.new_button.bind(on_press=lambda j: self.dispatch('on_new'))
+        self.content.bind(on_current_panel=self.on_current_panel)
+
+    def on_delete(self, *args):
+        '''Event handler for button "Delete" press
+        '''
+        pass
+
+    def on_new(self, *args):
+        '''Event handler for button "New" press
+        '''
+        pass
+
+    def on_use_this_profile(self, *args):
+        '''Event handler for button "Use this Profile" press
+        '''
+        pass
+
+    def on_current_panel(self, *args):
+        ''' Event handler to panel change
+        The default profile cannot be deleted, so we watch this event to
+        prevent the user to delete desktop.ini
+        '''
+        _file = self.content.current_panel.config.filename
+        filename = os.path.basename(_file)
+        self.button_bar.btn_delete_prof.disabled = filename == 'desktop.ini'
+
+
+class ProfileSettings(Settings):
+    '''Subclass of :class:`kivy.uix.settings.Settings` responsible for
+       showing build profile settings of Kivy Designer.
+    '''
+
+    config_parsers = DictProperty({})
+    '''List of config parsers
+    :class:`~kivy.properties.DictProperty` and defaults to {}.
+    '''
+
+    selected_config = ObjectProperty(None)
+    '''ConfigParser of the selected config
+    :class `~kivy.properties.ObjectProperty` and defaults to None.
+    '''
+
+    __events__ = ('on_use_this_profile', 'on_changed')
+
+    def __init__(self, **kwargs):
+        super(ProfileSettings, self).__init__(**kwargs)
+        # list of ConfigParsers. Each file has one to handle the settings
+        self.PROFILES_PATH = ''
+        self.DEFAULT_PROFILES = ''
+        self.interface.bind(on_new=self.on_new)
+        self.interface.bind(on_delete=self.on_delete)
+        self.interface.bind(
+            on_use_this_profile=lambda j: self.dispatch('on_use_this_profile'))
+        self.interface.content.bind(on_current_panel=self.on_current_config)
+        self.settings_changed = False  # changes in name, new or delete
+
+    def load_profiles(self):
+        '''This function loads project settings
+        '''
+        self.settings_changed = False
+        self.PROFILES_PATH = os.path.join(get_kivy_designer_dir(),
+            'profiles')
+
+        _dir = os.path.dirname(designer.__file__)
+        _dir = os.path.split(_dir)[0]
+        self.DEFAULT_PROFILES = os.path.join(_dir, 'profiles')
+
+        if not os.path.exists(self.PROFILES_PATH):
+            shutil.copytree(self.DEFAULT_PROFILES, self.PROFILES_PATH)
+
+        self.update_panel()
+
+    def update_panel(self):
+        '''Update the MenuSidebar
+        '''
+        _dir = os.path.dirname(designer.__file__)
+        _dir = os.path.split(_dir)[0]
+
+        self.config_parsers = {}
+        self.interface.menu.buttons_layout.clear_widgets()
+        for _file in os.listdir(self.PROFILES_PATH):
+            _file_path = os.path.join(self.PROFILES_PATH, _file)
+            config_parser = ConfigParser()
+            config_parser.read(_file_path)
+            prof_name = config_parser.getdefault('profile', 'name', 'PROFILE')
+            if not prof_name.strip():
+                prof_name = 'PROFILE'
+            self.config_parsers[prof_name + '_' + _file_path] = config_parser
+
+        for _file in sorted(self.config_parsers):
+            prof_name = self.config_parsers[_file].getdefault('profile',
+                                                              'name',
+                                                              'PROFILE')
+            if not prof_name.strip():
+                prof_name = 'PROFILE'
+            self.add_json_panel(prof_name,
+                                self.config_parsers[_file],
+                                os.path.join(
+                                    _dir,
+                                    'designer',
+                                    'settings',
+                                    'build_profile.json')
+                                )
+
+        # force to show the first profile
+        first_panel = self.interface.menu.buttons_layout.children[-1].uid
+        self.interface.content.current_uid = first_panel
+
+    def on_config_change(self, *args):
+        '''This function is default handler of on_config_change event.
+        '''
+        args[0].write()
+        super(ProfileSettings, self).on_config_change(*args)
+        if args[2] == 'name':
+            self.update_panel()
+            self.settings_changed = True
+
+    def on_new(self, *args):
+        '''Handler for "New Profile" button
+        '''
+        new_name = 'new_profile'
+        i = 1
+        while os.path.exists(os.path.join(
+                self.PROFILES_PATH, new_name + str(i) + '.ini')):
+            i += 1
+        new_name += str(i)
+        new_prof_path = os.path.join(
+            self.PROFILES_PATH, new_name + '.ini')
+
+        shutil.copy2(os.path.join(self.DEFAULT_PROFILES, 'desktop.ini'),
+                     new_prof_path)
+        config_parser = ConfigParser()
+        config_parser.read(new_prof_path)
+        config_parser.set('profile', 'name', new_name.upper())
+        config_parser.write()
+
+        self.update_panel()
+        self.settings_changed = True
+
+    def on_delete(self, *args):
+        '''Handler to "Delete profile" button
+        '''
+        self._confirm_dlg = ConfirmationDialog(
+            message="Do you want to delete this profile?")
+        self._popup = Popup(title='Delete Profile',
+                            content=self._confirm_dlg,
+                            size_hint=(None, None),
+                            size=('200pt', '150pt'),
+                            auto_dismiss=False)
+        self._confirm_dlg.bind(on_ok=self._perform_delete_prof,
+                               on_cancel=self._popup.dismiss)
+        self._popup.open()
+
+    def _perform_delete_prof(self, *args):
+        '''Delete the selected profile
+        '''
+        self.selected_config = self.interface.content.current_panel.config
+        os.remove(self.selected_config.filename)
+        self.update_panel()
+        self._popup.dismiss()
+        self.settings_changed = True
+
+    def on_use_this_profile(self, *args):
+        '''Event handler for button "Use this Profile" press
+        '''
+        self.selected_config = self.interface.content.current_panel.config
+        self.settings_changed = True
+
+    def on_current_config(self, *args):
+        ''' Event handler to panel change
+        The default profile cannot be deleted, so we watch this event to
+        prevent the user to delete desktop.ini
+        '''
+        self.selected_config = self.interface.content.current_panel.config
+
+    def on_changed(self, *args):
+        '''Event handler to Settings changes.
+        Will be called when the user delete,
+        create or change a name of a profile.
+        '''
+        pass
+
+    def on_close(self, *args):
+        '''Event handler when the settings is closed
+        '''
+        if self.settings_changed:
+            self.dispatch('on_changed')
+        self.settings_changed = False

--- a/designer/settings/build_profile.json
+++ b/designer/settings/build_profile.json
@@ -1,0 +1,54 @@
+[
+  {
+    "type": "string",
+    "title": "Name",
+    "section": "profile",
+    "desc": "Profile Name",
+    "key": "name"
+  },
+  {
+    "type": "options",
+    "title": "Builder",
+    "section": "profile",
+    "desc": "Select the builder.",
+    "options": ["Desktop", "Buildozer", "Hanga"],
+    "key": "builder"
+  },
+  {
+    "type": "options",
+    "title": "Target",
+    "section": "profile",
+    "desc": "Select the build target",
+    "options": ["Desktop", "Android", "iOS"],
+    "key": "target"
+  },
+  {
+    "type": "options",
+    "title": "Mode",
+    "section": "profile",
+    "desc": "Select the build mode.\nUsed with Android and iOS only.",
+    "options": ["Debug", "Release"],
+    "key": "mode"
+  },
+  {
+    "type": "bool",
+    "title": "Install on Device",
+    "section": "profile",
+    "desc": "Automatically install on device. \nUsed with Android and iOS only.",
+    "key": "install"
+  },
+  {
+    "type": "bool",
+    "title": "Debug",
+    "section": "profile",
+    "desc": "Show application output on console. \nUsed with Android(logcat)",
+    "key": "debug"
+  },
+  {
+    "type": "bool",
+    "title": "Verbose",
+    "section": "profile",
+    "desc": "Show verbose information while building the app. \nUsed with Android and iOS only.",
+    "key": "verbose"
+  }
+]

--- a/designer/uix/contextual.py
+++ b/designer/uix/contextual.py
@@ -506,6 +506,8 @@ class ContextSubMenu(MenuButton):
                 tab.show_arrow = False
 
         except:
+            if not self.cont_menu.current_tab in self.cont_menu.tab_list:
+                return
             curr_index = self.cont_menu.tab_list.index(
                 self.cont_menu.current_tab)
             for i in range(curr_index - 1, -1, -1):

--- a/designer/uix/contextual.py
+++ b/designer/uix/contextual.py
@@ -438,6 +438,13 @@ class ContextSubMenu(MenuButton):
         if hasattr(widget, 'cont_menu'):
             widget.cont_menu = self.cont_menu
 
+    def remove_children(self):
+        '''Clear _list_children[]
+        '''
+        for child, index in self._list_children:
+            self.container.remove_widget(child)
+        self._list_children = []
+
     def on_cont_menu(self, *args):
         '''Default handler for cont_menu.
         '''

--- a/profiles/android_buildozer.ini
+++ b/profiles/android_buildozer.ini
@@ -1,0 +1,9 @@
+[profile]
+name = Android - Buildozer
+builder = Buildozer
+target = Android
+mode = Debug
+install = False
+debug = False
+verbose = False
+

--- a/profiles/desktop.ini
+++ b/profiles/desktop.ini
@@ -1,0 +1,8 @@
+[profile]
+name = Desktop
+builder = Desktop
+target = Desktop
+mode = Debug
+install = False
+debug = False
+verbose = False

--- a/profiles/ios_buildozer.ini
+++ b/profiles/ios_buildozer.ini
@@ -1,0 +1,9 @@
+[profile]
+name = iOS - Buildozer
+builder = Buildozer
+target = iOS
+mode = Debug
+install = False
+debug = False
+verbose = False
+


### PR DESCRIPTION
# PR Overview 

## Build Profile
In this PR I'm adding the Build Profiles.
Kivy Designer is now integrated with Buildozer and soon with Hanga(maybe new tools in the future ?). To handle these multiple targets and options, I created a **"Build Profile"** settings.

The user is able to edit these profiles, create new ones or even delete them. Now it's just necessary to change the profile to build the same application to the desired target :)

There are three default profiles:

* Desktop
* Android - Buildozer
* iOS - Buildozer 

And the user can easily edit the default settings and create new profiles.

## Screenshots:

* Build Profiles main screen
![screenshot from 2015-06-23 23-12-14](https://cloud.githubusercontent.com/assets/4960137/8321449/648a15ee-19fd-11e5-9836-9cc715b8dbd7.png)

* Profile selection
![screenshot from 2015-06-23 23-17-29](https://cloud.githubusercontent.com/assets/4960137/8321503/17ddee72-19fe-11e5-93ff-70768f1698ea.png)
![screenshot from 2015-06-23 23-17-35](https://cloud.githubusercontent.com/assets/4960137/8321502/17dc78ee-19fe-11e5-8d33-8252ded6b52d.png)


