### PR TITLE
[BUG-FIX|IMPORTANT] fix menusidebar name

### DIFF
--- a/designer/designer.kv
+++ b/designer/designer.kv
@@ -567,7 +567,7 @@
             id: content
             current_uid: menu.selected_uid
 
-<-MenuSidebar>:
+<-SpecMenuSidebar>:
     size_hint_x: None
     width: '200dp'
     buttons_layout: menu


### PR DESCRIPTION
Sry, there was a wrong class name in my last PR.  SpecMenuSidebar is a custom MenuSidebar to be used only with buildozer spec editor. The name was <MenuSidebar> which is being used by the whole KV
