### PR TITLE
fix #83 - handle custom ActionGroup if Window.size is small

### DIFF
--- a/designer/designer.kv
+++ b/designer/designer.kv
@@ -1212,7 +1212,7 @@
         id: actionbar
         pos_hint: {'top': 1}
         on_height: root.on_actionbar_height()
-        ActionView:
+        DesignerActionView:
             ActionPrevious:
                 title: 'Kivy Designer'
                 with_previous: False


### PR DESCRIPTION
if the screen is too small, actionbar tries to group items. As long as KD uses custom items on ActionGroups, it was not working. 