### PR TITLE
project loader small fixes - fix #97

### DIFF
--- a/designer/project_loader.py
+++ b/designer/project_loader.py
@@ -27,10 +27,12 @@ from designer.proj_watcher import ProjectWatcher
 PROJ_DESIGNER = '.designer'
 KV_PROJ_FILE_NAME = os.path.join(PROJ_DESIGNER, 'kvproj')
 PROJ_FILE_CONFIG = os.path.join(PROJ_DESIGNER, 'file_config.ini')
+ignored_paths = ('.designer', '.buildozer', '.git', '__pycache__', 'bin', )
 
 
 class Comment(object):
-
+    '''Comment is an Abstract class for representing a commentary.
+    '''
     def __init__(self, string, path, _file):
         super(Comment, self).__init__()
         self.string = string
@@ -112,8 +114,12 @@ class ProjectLoader(object):
         '''
 
         file_list = []
-        if '.designer' in path:
-            return []
+        for ignored in ignored_paths:
+            if ignored in path:
+                return []
+
+        if os.path.isfile(path):
+            path = os.path.dirname(path)
 
         sys.path.insert(0, path)
         self._dir_list.append(path)
@@ -315,7 +321,8 @@ class ProjectLoader(object):
                 else:
                     self._is_root_already_in_factory = False
 
-                root_rule = Builder.load_string(re.sub(r'\s+on_\w+:\w+',
+                re_kv_event = r'(\s+on_\w+\s*:.+)|([\s\w\d]+:[\.\s\w]+\(.*\))'
+                root_rule = Builder.load_string(re.sub(re_kv_event,
                                                        '', kv_string))
                 if root_rule:
                     self.root_rule = RootRule(root_rule.__class__.__name__,
@@ -485,7 +492,7 @@ class ProjectLoader(object):
                 self.dict_file_type_and_path[file_type] + '">\n'
         string += '</file_type_and_dirs>\n'
 
-        f = open(os.path.join(self.proj_dir, PROJ_CONFIG), 'w')
+        f = open(os.path.join(self.proj_dir, PROJ_FILE_CONFIG), 'w')
         f.write(string)
         f.close()
 
@@ -515,9 +522,8 @@ class ProjectLoader(object):
             os.mkdir(auto_save_dir)
 
         for _file in os.listdir(self.proj_dir):
-            if '.designer' in _file:
+            if list(set(ignored_paths) & {_file}):
                 continue
-
             old_file = os.path.join(self.proj_dir, _file)
             new_file = os.path.join(auto_save_dir, _file)
             if os.path.isdir(old_file):
@@ -909,7 +915,7 @@ class ProjectLoader(object):
            defined/used in string s.
         '''
 
-        if 'runTouchApp' in s:
+        if 'runTouchApp(' in s:
             self._app_class = 'runTouchApp'
             return True
 
@@ -917,7 +923,10 @@ class ProjectLoader(object):
             for _class in re.findall(r'\bclass\b.+:', s):
                 b_index1 = _class.find('(')
                 b_index2 = _class.find(')')
-                if _class[b_index1 + 1:b_index2].strip() == 'App':
+                classes = _class[b_index1 + 1:b_index2]
+                classes = re.sub(r'[\s]+', '', classes)
+                classes = classes.split(',')
+                if 'App' in classes:
                     self._app_class = _class[_class.find(' '):b_index1].strip()
                     return True
 
@@ -959,23 +968,25 @@ class ProjectLoader(object):
 
         # If cannot find due to above methods, search every file
         for _file in self.file_list:
-            f = open(_file, 'r')
-            s = f.read()
-            f.close()
-            if not self._app_file and self._app_in_string(s):
-                self._app_module = self._import_module(s, _file)
-                self._app_file = _file
+            if _file[_file.rfind('.') + 1:] == 'py':
+                f = open(_file, 'r')
+                s = f.read()
+                f.close()
+                if not self._app_file and self._app_in_string(s):
+                    self._app_module = self._import_module(s, _file)
+                    self._app_file = _file
 
-            for _rule in to_find[:]:
-                if _rule.file:
-                    continue
+                for _rule in to_find[:]:
+                    if _rule.file:
+                        continue
 
-                if re.search(r'\bclass\s*%s+.+:' % (_rule.name), s):
-                    mod = self._import_module(s, _file, _fromlist=[_rule.name])
-                    if hasattr(mod, _rule.name):
-                        _rule.file = _file
-                        to_find.remove(_rule)
-                        _rule.module = mod
+                    if re.search(r'\bclass\s*%s+.+:' % (_rule.name), s):
+                        mod = self._import_module(s, _file,
+                                                  _fromlist=[_rule.name])
+                        if hasattr(mod, _rule.name):
+                            _rule.file = _file
+                            to_find.remove(_rule)
+                            _rule.module = mod
 
         # Cannot Find App, So, use default runTouchApp
         if not self._app_file:
@@ -1002,6 +1013,7 @@ class ProjectLoader(object):
 
         run_pos = s.rfind('().run()')
 
+        i = None
         if run_pos != -1:
             run_pos -= 1
             while not s[run_pos].isspace():
@@ -1011,7 +1023,7 @@ class ProjectLoader(object):
             while s[i] == ' ':
                 i -= 1
 
-        if i == run_pos - 1 or _r != []:
+        if i is not None and i == run_pos - 1 or _r != []:
             if i == run_pos - 1:
                 s = s.replace('%s().run()' % self._app_class, '')
 


### PR DESCRIPTION
Fixes:
* [cannot open buildozer project](https://github.com/aron-bordin/kivy-designer/issues/76)
* https://github.com/kivy/kivy-designer/issues/97
* [MainApp class must inherits only the App](https://github.com/aron-bordin/kivy-designer/issues/82)
* [load_proj_config do nothing](https://github.com/aron-bordin/kivy-designer/issues/84)
* [autosave backups .buildozer, .git, .designer and bin folder](https://github.com/aron-bordin/kivy-designer/issues/85)
* [Project loader cannot read some events](https://github.com/aron-bordin/kivy-designer/issues/92)
* [KD accepts any 'runTouchApp' string as app run](https://github.com/aron-bordin/kivy-designer/issues/93)
* [Trying to import both .py and .pyc modules](https://github.com/aron-bordin/kivy-designer/issues/81)