### PR TITLE
Kivy Designer Tools

### DIFF
--- a/designer/app.py
+++ b/designer/app.py
@@ -1,4 +1,5 @@
 import webbrowser
+from designer.designer_tools import DesignerTools
 from designer.input_dialog import InputDialog
 from designer.profile_settings import ProfileSettings
 from designer.profiler import Profiler
@@ -73,6 +74,10 @@ class Designer(FloatLayout):
 
     spec_editor = ObjectProperty(None)
     '''Instance of :class:`designer.buildozer_spec_editor.BuildozerSpecEditor`
+    '''
+
+    designer_tools = ObjectProperty(None)
+    '''Instance of :class:`designer.designer_tools.DesignerTools`
     '''
 
     statusbar = ObjectProperty(None)
@@ -202,6 +207,8 @@ class Designer(FloatLayout):
         self.profiler.bind(on_message=self.on_profiler_message)
         self.profiler.bind(on_run=self.on_profiler_run)
         self.profiler.bind(on_stop=self.on_profiler_stop)
+
+        self.designer_tools = DesignerTools(designer=self)
 
         Window.bind(on_resize=self._write_window_size)
         Window.bind(on_request_close=self.on_request_close)
@@ -365,6 +372,7 @@ class Designer(FloatLayout):
         self.ids['actn_menu_view'].disabled = False
         self.ids['actn_menu_proj'].disabled = False
         self.ids['actn_menu_run'].disabled = False
+        self.ids['actn_menu_tools'].disabled = False
 
         self.proj_settings = ProjectSettings(proj_loader=self.project_loader)
         self.proj_settings.load_proj_settings()
@@ -726,6 +734,7 @@ class Designer(FloatLayout):
         self.ids['actn_menu_view'].disabled = True
         self.ids['actn_menu_proj'].disabled = True
         self.ids['actn_menu_run'].disabled = True
+        self.ids['actn_menu_tools'].disabled = True
 
         self.project_watcher.stop()
 

--- a/designer/designer.kv
+++ b/designer/designer.kv
@@ -214,6 +214,72 @@
 
 <ProfileContentPanel>:
 
+#
+# Tools
+#
+
+<SetupPyLabel@Label>:
+    text_size: self.size
+    valign: 'middle'
+    halign: 'left'
+
+<ToolSetupPy>:
+    orientation: 'vertical'
+    padding: 10
+    spacing: 15
+    BoxLayout:
+        BoxLayout:
+            size_hint_x: 0.3
+            orientation: 'vertical'
+            SetupPyLabel:
+                text: 'Package Name: '
+            SetupPyLabel:
+                text: 'Version: '
+            SetupPyLabel:
+                text: 'URL: '
+            SetupPyLabel:
+                text: 'License: '
+            SetupPyLabel:
+                text: 'Author: '
+            SetupPyLabel:
+                text: 'Author Email: '
+            SetupPyLabel:
+                text: 'Description: '
+        BoxLayout:
+            size_hint_x: 0.7
+            orientation: 'vertical'
+            TextInput:
+                id: package_name
+                multiline: False
+            TextInput:
+                id: version
+                multiline: False
+            TextInput:
+                id: url
+                multiline: False
+            TextInput:
+                id: license
+                multiline: False
+            TextInput:
+                id: author
+                multiline: False
+            TextInput:
+                id: author_email
+                multiline: False
+            TextInput:
+                id: description
+                multiline: False
+    GridLayout:
+        cols: 2
+        size_hint_y: None
+        height: self.minimum_height
+        DesignerButton:
+            text: 'Create'
+            on_press: root.create()
+        DesignerButton:
+            text: 'cancel'
+            on_press: root.dispatch('on_cancel')
+
 <MenuHeader>
     color: (1, 1, 1, 1) if self.state == 'normal' else (0, 0, 0, 1)
     font_size: '12dp'
@@ -1507,6 +1573,35 @@
                     id: actn_btn_edit_prof_proj
                     text: 'Edit Profiles...'
                     on_release: root.action_btn_edit_prof_project_pressed()
+
+            DesignerActionGroup:
+                id: actn_menu_tools
+                text: 'Tools'
+                mode: 'spinner'
+                size_hint_x: None
+                dropdown_cls: ContextMenu
+                disabled: True
+                DesignerActionButton:
+                    id: actn_btn_buildozer_init
+                    text: 'Buildozer Init'
+                    on_release: root.designer_tools.buildozer_init()
+                DesignerActionButton:
+                    id: actn_btn_export_png
+                    text: 'Export .png'
+                    on_release: root.designer_tools.export_png()
+                DesignerActionButton:
+                    id: actn_btn_check_pep8
+                    text: 'Check PEP 8'
+                    on_release: root.designer_tools.check_pep8()
+                DesignerActionButton:
+                    id: actn_btn_create_setup_py
+                    text: 'Create setup.py'
+                    on_release: root.designer_tools.create_setup_py()
+                DesignerActionButton:
+                    id: actn_btn_create_gitignore
+                    text: 'Create .gitignore'
+                    on_release: root.designer_tools.create_gitignore()
+
 
             DesignerActionGroup:
                 id: actn_menu_help

--- a/designer/designer_tools.py
+++ b/designer/designer_tools.py
@@ -1,0 +1,217 @@
+import datetime
+import os
+import shutil
+import designer
+
+from kivy.event import EventDispatcher
+from kivy.properties import ObjectProperty, StringProperty
+from designer.confirmation_dialog import ConfirmationDialog
+from kivy.uix.boxlayout import BoxLayout
+from kivy.uix.popup import Popup
+from designer.helper_functions import ignore_proj_watcher, show_alert
+
+
+#### UIs ####
+class ToolSetupPy(BoxLayout):
+
+    path = StringProperty('')
+    '''setup.py path
+       Instance of :class:`kivy.config.StringProperty`
+    '''
+
+    __events__ = ('on_create', 'on_cancel', )
+
+    @ignore_proj_watcher
+    def create(self):
+        '''Create the setup.py
+        '''
+        package_name = self.ids.package_name.text
+        version = self.ids.version.text
+        url = self.ids.url.text
+        license = self.ids.license.text
+        author = self.ids.author.text
+        author_email = self.ids.author_email.text
+        description = self.ids.description.text
+
+        setup_template = '''from distutils.core import setup
+
+setup(
+    name='%s',
+    version='%s',
+    packages=[],
+    url='%s',
+    license='%s',
+    author='%s',
+    author_email='%s',
+    description='%s',
+)
+'''
+        setup = setup_template % (
+            package_name,
+            version,
+            url,
+            license,
+            author,
+            author_email,
+            description,
+        )
+
+        f = open(self.path, 'w').write(setup)
+
+        self.dispatch('on_create')
+
+    def on_create(self, *args):
+        '''Event handler to "Create" button'''
+        pass
+
+    def on_cancel(self, *args):
+        '''Event handler to "Cancel" button'''
+        pass
+
+
+### Tools ###
+class DesignerTools(EventDispatcher):
+
+    designer = ObjectProperty()
+    '''Instance of Designer
+       :data:`designer` is a :class:`~kivy.properties.ObjectProperty`
+    '''
+
+    @ignore_proj_watcher
+    def export_png(self):
+        '''Export playground widget to png file.
+        If there is a selected widget, export it.
+        If not, export the root widget
+        '''
+        playground = self.designer.ui_creator.playground
+        proj_dir = self.designer.project_loader.proj_dir
+        status = self.designer.statusbar
+
+        wdg = playground.selected_widget
+        if wdg is None:
+            wdg = playground.root
+
+        name = datetime.datetime.now().strftime("%m-%d-%Y_%H-%M-%S.png")
+        if wdg.id:
+            name = wdg.id + '_' + name
+        wdg.export_to_png(os.path.join(proj_dir, name))
+        status.show_message('Image saved at ' + name, 5)
+
+    def check_pep8(self):
+        '''Check the PEP8 from current project
+        '''
+        proj_dir = self.designer.project_loader.proj_dir
+        kd_dir = os.path.dirname(designer.__file__)
+        kd_dir = os.path.split(kd_dir)[0]
+        pep8_dir = os.path.join(kd_dir, 'tools', 'pep8checker',
+                                'pep8kivy.py')
+
+        python_path =\
+            self.designer.designer_settings.config_parser.getdefault(
+                'global',
+                'python_shell_path',
+                ''
+            )
+
+        if python_path == '':
+            self.profiler.dispatch('on_error', 'Python Shell Path not '
+                                   'specified.'
+                                   '\n\nUpdate it on \'File\' -> \'Settings\'')
+            return
+
+        cmd = '%s %s %s' % (python_path, pep8_dir, proj_dir)
+        self.designer.ui_creator.tab_pannel.switch_to(
+            self.designer.ui_creator.tab_pannel.tab_list[2])
+        self.designer.ui_creator.kivy_console.run_command(cmd)
+
+    def create_setup_py(self):
+        '''Runs the GUI to create a setup.py file
+        '''
+        proj_loader = self.designer.project_loader
+        proj_dir = proj_loader.proj_dir
+        designer_content = self.designer.designer_content
+
+        setup_path = os.path.join(proj_dir, 'setup.py')
+        if os.path.exists(setup_path):
+            show_alert('Create setup.py', 'setup.py already exists!')
+            return False
+
+        content = ToolSetupPy(path=setup_path)
+        self._popup = Popup(title='Create setup.py', content=content,
+                            size_hint=(None, None), size=(550, 400),
+                            auto_dismiss=False)
+        content.bind(on_cancel=self._popup.dismiss)
+
+        def on_create(*args):
+            designer_content.update_tree_view(proj_loader)
+            self._popup.dismiss()
+
+        content.bind(on_create=on_create)
+        self._popup.open()
+
+    @ignore_proj_watcher
+    def create_gitignore(self):
+        '''Create .gitignore
+        '''
+        proj_loader = self.designer.project_loader
+        proj_dir = proj_loader.proj_dir
+        status = self.designer.statusbar
+
+        gitignore_path = os.path.join(proj_dir, '.gitignore')
+
+        if os.path.exists(gitignore_path):
+            show_alert('Create .gitignore', '.gitignore already exists!')
+            return False
+
+        gitignore = '''*.pyc
+*.pyo
+bin/
+.designer/
+.buildozer/
+__pycache__/'''
+
+        f = open(gitignore_path, 'w').write(gitignore)
+        status.show_message('.gitignore created successfully', 5)
+
+    def buildozer_init(self):
+        '''Checks if the .spec exists or not; and when possible, calls
+            _perform_buildozer_init
+        '''
+
+        proj_loader = self.designer.project_loader
+        proj_dir = proj_loader.proj_dir
+        spec_file = os.path.join(proj_dir, 'buildozer.spec')
+
+        if os.path.exists(spec_file):
+            self._confirm_dlg = ConfirmationDialog(
+                message='The buildozer.spec file already exist.'
+                                        '\nDo you want to create a new spec?')
+            self._popup = Popup(title='Buildozer init',
+                                content=self._confirm_dlg,
+                                size_hint=(None, None),
+                                size=('250pt', '150pt'),
+                                auto_dismiss=False)
+            self._confirm_dlg.bind(on_ok=self._perform_buildozer_init,
+                                   on_cancel=self._popup.dismiss)
+            self._popup.open()
+        else:
+            self._perform_buildozer_init()
+
+    @ignore_proj_watcher
+    def _perform_buildozer_init(self, *args):
+        '''Copies the spec from new_templates/default.spec to the project
+        folder
+        '''
+        self._popup.dismiss()
+
+        proj_loader = self.designer.project_loader
+        proj_dir = proj_loader.proj_dir
+        spec_file = os.path.join(proj_dir, 'buildozer.spec')
+
+        _dir = os.path.dirname(designer.__file__)
+        _dir = os.path.split(_dir)[0]
+        templates_dir = os.path.join(_dir, 'new_templates')
+        shutil.copy(os.path.join(templates_dir, 'default.spec'), spec_file)
+
+        self.designer.designer_content.update_tree_view(
+            self.designer.project_loader)

--- a/designer/helper_functions.py
+++ b/designer/helper_functions.py
@@ -94,3 +94,14 @@ def show_alert(title, msg, width=500, height=200):
                         size_hint=(None, None),
                         size=(width, height))
     popup.open()
+
+
+def ignore_proj_watcher(f):
+    '''Function decorator to makes project watcher ignores file modification
+    '''
+    def wrapper(*args, **kwargs):
+        watcher = App.get_running_app().root.project_watcher
+        watcher.stop()
+        f(*args, **kwargs)
+        return watcher.resume_watching()
+    return  wrapper

--- a/designer/proj_watcher.py
+++ b/designer/proj_watcher.py
@@ -77,3 +77,12 @@ class ProjectWatcher(object):
         '''join observer after unschedulling it
         '''
         self._observer.join()
+
+    def resume_watching(self):
+        '''Resume watching the project if self._project_dir exists
+        '''
+        if self._project_dir:
+            self.start_watching(self._project_dir)
+            return True
+        else:
+            return False

--- a/designer/proj_watcher.py
+++ b/designer/proj_watcher.py
@@ -36,6 +36,7 @@ class ProjectWatcher(object):
         self._event_handler = None
         self._callback = callback
         self.allow_event_dispatch = True
+        self._project_dir = None
 
     def start_watching(self, project_dir):
         '''To start watching project_dir.

--- a/tools/pep8checker/pep8kivy.py
+++ b/tools/pep8checker/pep8kivy.py
@@ -57,7 +57,8 @@ if __name__ == '__main__':
         return checker.check_all()
 
     errors = 0
-    exclude_dirs = ['/lib', '/coverage', '/pep8', '/doc']
+    exclude_dirs = ['/lib', '/coverage', '/pep8', '/doc', '/.designer',
+                    '/.buildozer']
     exclude_files = ['kivy/gesture.py', 'osx/build.py', 'win32/build.py',
                      'kivy/tools/stub-gl-debug.py',
                      'kivy/modules/webdebugger.py',


### PR DESCRIPTION
# PR Overview

This is a simple chain of tools to help in the project development.
#### Buildozer init
Creates a default buildozer.spec in the project root

#### Export .png
A helper to create a .png image from the application UI or from the selected widget on Playground

#### Check pep8
A simple shortcut to run a pep8 checker in the project under development.

#### Create Setup.py
A UI tool to help you to create a setup.py to your application.

![](https://cloud.githubusercontent.com/assets/4960137/8395099/3eabc318-1d31-11e5-8a7f-ebabcd2832c1.png)

#### Create .gitignore
Creates a simple .gitignore to kivy designer projects