### PR TITLE
Kivy Modules

### DIFF
--- a/config.ini
+++ b/config.ini
@@ -20,6 +20,9 @@ exit_on_escape = 0
 window_width = 800
 window_height = 600
 default_profile =
+mod_screen_scale = 1.0
+mod_screen_orientation = portrait
+mod_screen_device =
 
 [view]
 actn_chk_proj_tree = True

--- a/designer/app.py
+++ b/designer/app.py
@@ -2,6 +2,7 @@ import webbrowser
 from designer.input_dialog import InputDialog
 from designer.profile_settings import ProfileSettings
 from designer.profiler import Profiler
+from designer.uix.modules_contview import ModulesContView
 
 __all__ = ('DesignerApp', )
 
@@ -36,6 +37,7 @@ from designer.uix.actioncheckbutton import ActionCheckButton
 from designer.playground import PlaygroundDragElement
 from designer.common import widgets
 from designer.uix.editcontview import EditContView
+from designer.uix.modules_contview import ModulesContView
 from designer.uix.kv_lang_area import KVLangArea
 from designer.undo_manager import WidgetOperation, UndoManager
 from designer.project_loader import ProjectLoader, ProjectLoaderException
@@ -53,7 +55,7 @@ from designer.helper_functions import get_kivy_designer_dir, show_alert
 from designer.new_dialog import NewProjectDialog, NEW_PROJECTS
 from designer.eventviewer import EventViewer
 from designer.uix.designer_action_items import DesignerActionButton, \
-    DesignerActionProfileCheck
+    DesignerActionProfileCheck, DesignerActionSubMenu
 from designer.help_dialog import HelpDialog, AboutDialog
 from designer.uix.bug_reporter import BugReporterApp
 from designer.buildozer_spec_editor import BuildozerSpecEditor
@@ -82,7 +84,12 @@ class Designer(FloatLayout):
 
     editcontview = ObjectProperty(None)
     '''Reference to the :class:`~designer.uix.EditContView` instance.
-       :data:`v` is a :class:`~kivy.properties.ObjectProperty`
+       :data:`editcontview` is a :class:`~kivy.properties.ObjectProperty`
+    '''
+
+    modulescontview = ObjectProperty(None)
+    '''Reference to the :class:`~designer.uix.modules_contview.ModulesContView`.
+       :data:`modulescontview` is a :class:`~kivy.properties.ObjectProperty`
     '''
 
     actionbar = ObjectProperty(None)
@@ -152,7 +159,8 @@ class Designer(FloatLayout):
     select_profile_cont_menu = ObjectProperty(None)
     '''Reference of
         :class:`~designer.uix.designer_action_items.DesignerActionSubMenu`.
-       :data:`start_page` is a :class:`~kivy.properties.ObjectProperty`
+       :data:`select_profile_cont_menu` is a
+       :class:`~kivy.properties.ObjectProperty`
     '''
 
     selected_profile = StringProperty('')
@@ -1028,18 +1036,20 @@ class Designer(FloatLayout):
             btn.text = prof_name
             btn.checkbox.active = False
 
+            btn.config_key = profile
+            btn.bind(on_active=self._perform_profile_selected)
+
             if self.designer_settings.config_parser.getdefault('internal',
                                         'default_profile', '') == config_path:
                 btn.checkbox.active = True
                 self.selected_profile = config_path
+                self._perform_profile_selected(btn, btn.checkbox, True)
 
-            btn.config_key = profile
-            btn.bind(on_active=self._perform_profile_selected)
             prof_menu.add_widget(btn)
 
         prof_menu._add_widget()
 
-    def _perform_profile_selected(self, instance, item, value, *args):
+    def _perform_profile_selected(self, instance, checkbox, value, *args):
         '''Event handler to select profile radio button.
         Save the selected config_parser path to the config
         '''
@@ -1051,6 +1061,13 @@ class Designer(FloatLayout):
                                                      _config_path)
             self.designer_settings.config_parser.write()
             self.selected_profile = _config_path
+
+            target = _config.getdefault('profile', 'target', '')
+
+            if target == 'Desktop':
+                self.ids.actn_btn_run_module.disabled = False
+            else:
+                self.ids.actn_btn_run_module.disabled = True
 
     def action_btn_recent_files_pressed(self, *args):
         '''Event Handler when ActionButton "Recent Projects" is pressed.
@@ -1441,6 +1458,15 @@ class Designer(FloatLayout):
 
         self._popup.open()
 
+    def action_btn_run_module_pressed(self, *args):
+
+        if self.modulescontview is None:
+            self.modulescontview = ModulesContView()
+            self.modulescontview.bind(
+                on_module=self.action_btn_run_project_pressed)
+
+        self.actionbar.add_widget(self.modulescontview)
+
     def action_btn_project_settings_pressed(self, *args):
         '''Event Handler when ActionButton "Project Settings" is pressed.
         '''
@@ -1508,7 +1534,7 @@ class Designer(FloatLayout):
             return
         self.profiler.rebuild()
 
-    def action_btn_run_project_pressed(self, *args):
+    def action_btn_run_project_pressed(self, *args, **kwargs):
         '''Event Handler when ActionButton "Run" is pressed.
         '''
         if not self.check_selected_prof():
@@ -1516,7 +1542,7 @@ class Designer(FloatLayout):
         if self.project_loader.file_list == []:
             return
 
-        self.profiler.run()
+        self.profiler.run(*args, **kwargs)
 
     def on_sandbox_getting_exception(self, *args):
         '''Event Handler for

--- a/designer/designer.kv
+++ b/designer/designer.kv
@@ -240,7 +240,6 @@
 
 <MenuButton>:
     background_normal: 'atlas://data/images/defaulttheme/action_item'
-    background_disabled_normal: 'atlas://data/images/defaulttheme/action_item'
     background_down: 'atlas://data/images/defaulttheme/action_item_down'
     background_disabled_down: 'atlas://data/images/defaulttheme/action_item_down'
 
@@ -748,6 +747,106 @@
         cols: 1
         size_hint_y: None
         height: max(self.minimum_height, root.height)
+
+<DesignerActionGroup>:
+    mode: 'spinner'
+    size_hint_x: None
+    dropdown_cls: ContextMenu
+
+<ModScreenContView>:
+    ActionPrevious:
+        title: "Screen"
+        width: 100
+        with_previous: True
+    ActionOverflow:
+    ActionButton:
+        text: 'Run'
+        on_release: root.on_run_press()
+    DesignerActionGroup:
+        id: module_screen_device
+        text: 'Device'
+    DesignerActionGroup:
+        id: module_screen_orientation
+        text: 'Orientation'
+        DesignerActionProfileCheck:
+            text: 'Portrait'
+            group: 'mod_screen_orientation'
+            allow_no_selection: False
+            checkbox_active: False
+            config_key: 'portrait'
+            on_active: root.on_module_settings(self)
+        DesignerActionProfileCheck:
+            text: 'Landscape'
+            group: 'mod_screen_orientation'
+            allow_no_selection: False
+            checkbox_active: False
+            config_key: 'landscape'
+            on_active: root.on_module_settings(self)
+    DesignerActionGroup:
+        id: module_screen_scale
+        text: 'Scale'
+        DesignerActionProfileCheck:
+            id: module_screen_25
+            text: '25%'
+            group: 'mod_screen_scale'
+            allow_no_selection: False
+            checkbox_active: False
+            config_key: '0.25'
+            on_active: root.on_module_settings(self)
+        DesignerActionProfileCheck:
+            id: module_screen_50
+            text: '50%'
+            group: 'mod_screen_scale'
+            allow_no_selection: False
+            checkbox_active: False
+            config_key: '0.50'
+            on_active: root.on_module_settings(self)
+        DesignerActionProfileCheck:
+            id: module_screen_100
+            text: '100%'
+            group: 'mod_screen_scale'
+            allow_no_selection: False
+            checkbox_active: False
+            config_key: '1.0'
+            on_active: root.on_module_settings(self)
+        DesignerActionProfileCheck:
+            id: module_screen_150
+            text: '150%'
+            group: 'mod_screen_scale'
+            allow_no_selection: False
+            checkbox_active: False
+            config_key: '1.5'
+            on_active: root.on_module_settings(self)
+        DesignerActionProfileCheck:
+            id: module_screen_200
+            text: '200%'
+            group: 'mod_screen_scale'
+            allow_no_selection: False
+            checkbox_active: False
+            config_key: '2.0'
+            on_active: root.on_module_settings(self)
+
+<ModulesContView>:
+    ActionPrevious:
+        title: "Modules"
+        width: 100
+        with_previous: True
+    ActionOverflow:
+    ActionButton:
+        text: 'Screen Emulation'
+        on_release: root.on_screen()
+    ActionButton:
+        text: 'Touchring'
+        on_release: root.dispatch('on_module', mod='touchring', data=[])
+    ActionButton:
+        text: 'Monitor'
+        on_release: root.dispatch('on_module', mod='monitor', data=[])
+    ActionButton:
+        text: 'Inspector'
+        on_release: root.dispatch('on_module', mod='inspector', data=[])
+    ActionButton:
+        text: 'Web Debugger'
+        on_release: root.on_webdebugger(self)
 
 <EditContView>:
     ActionPrevious:
@@ -1368,9 +1467,6 @@
             DesignerActionGroup:
                 id: actn_menu_file
                 text: 'File'
-                mode: 'spinner'
-                size_hint_x: None
-                dropdown_cls: ContextMenu
                 DesignerActionButton:
                     id: actn_btn_new_file
                     text: 'New File'
@@ -1411,10 +1507,6 @@
             DesignerActionGroup:
                 id: actn_menu_view
                 text: 'View'
-                mode: 'spinner'
-                size_hint_x: None
-                width: 90
-                dropdown_cls: ContextMenu
                 disabled: True
                 ActionCheckButton:
                     id: actn_chk_proj_tree
@@ -1449,10 +1541,6 @@
             DesignerActionGroup:
                 id: actn_menu_proj
                 text: 'Project'
-                mode: 'spinner'
-                size_hint_x: None
-                width: 90
-                dropdown_cls: ContextMenu
                 disabled: True
                 DesignerActionButton:
                     id: actn_btn_add_file
@@ -1472,15 +1560,15 @@
             DesignerActionGroup:
                 id: actn_menu_run
                 text: 'Run'
-                mode: 'spinner'
-                size_hint_x: None
-                width: 90
-                dropdown_cls: ContextMenu
                 disabled: True
                 DesignerActionButton:
                     id: actn_btn_run_proj
                     text: 'Run'
                     on_release: root.action_btn_run_project_pressed()
+                DesignerActionButton:
+                    id: actn_btn_run_module
+                    text: 'Run with module...'
+                    on_release: root.action_btn_run_module_pressed()
                 DesignerActionButton:
                     id: actn_btn_stop_proj
                     disabled: True
@@ -1511,10 +1599,6 @@
             DesignerActionGroup:
                 id: actn_menu_help
                 text: 'Help'
-                mode: 'spinner'
-                size_hint_x: None
-                width: 90
-                dropdown_cls: ContextMenu
                 DesignerActionButton:
                     id: actn_btn_help
                     text: 'Help'

--- a/designer/designer.kv
+++ b/designer/designer.kv
@@ -623,7 +623,7 @@
             size_hint_x: None
             width: '20sp'
             pos: root.x + 2, root.y
-            active: True
+            active: root.checkbox_active
             group: root.group
             allow_no_selection: root.allow_no_selection
             on_active: root.dispatch('on_active', *args)

--- a/designer/uix/designer_action_items.py
+++ b/designer/uix/designer_action_items.py
@@ -32,7 +32,7 @@ class DesignerActionProfileCheck(ActionCheckButton):
         super(DesignerActionProfileCheck, self).__init__(**kwargs)
         self.minimum_width = 200
         self.size_hint_y = None
-        self.height = sp(48)
+        self.height = sp(49)
 
 
 class DesignerActionGroup(ActionGroup):

--- a/designer/uix/modules_contview.py
+++ b/designer/uix/modules_contview.py
@@ -1,0 +1,134 @@
+from kivy.app import App
+from kivy.properties import ObjectProperty, Clock, partial
+from kivy.uix.actionbar import ContextualActionView
+from kivy.modules import screen
+import webbrowser
+from designer.uix.designer_action_items import DesignerActionProfileCheck
+
+
+class ModulesContView(ContextualActionView):
+
+    mod_screen = ObjectProperty(None)
+
+    __events__ = ('on_module', )
+
+    def on_module(self, *args, **kwargs):
+        '''Dispatch the selected module
+        '''
+        self.parent.on_previous(self)
+
+    def on_screen(self, *args):
+        '''Screen module selected, shows ModScreenContView menu
+        '''
+        if self.mod_screen is None:
+            self.mod_screen = ModScreenContView()
+            self.mod_screen.bind(on_run=self.on_screen_module)
+        self.parent.add_widget(self.mod_screen)
+
+    def on_screen_module(self, *args, **kwargs):
+        '''when running from screen module
+        '''
+        self.mod_screen.parent.on_previous(self.mod_screen)
+        self.dispatch('on_module', *args, **kwargs)
+
+    def on_webdebugger(self, *args):
+        '''when running from webdebugger'''
+        self.dispatch('on_module', mod='webdebugger', data=[])
+        Clock.schedule_once(partial(webbrowser.open,
+                                    'http://localhost:5000/'), 5)
+
+
+class ModScreenContView(ContextualActionView):
+
+    __events__ = ('on_run', )
+
+    designer = ObjectProperty(None)
+    '''Instance of Desiger
+    '''
+
+    def __init__(self, **kwargs):
+        super(ModScreenContView, self).__init__(**kwargs)
+
+        # populate emulation devices
+        devices = self.ids.module_screen_device
+
+        self.designer = App.get_running_app().root
+        config = self.designer.designer_settings.config_parser
+
+        # load the default values
+        saved_device = config.getdefault('internal', 'mod_screen_device', '')
+        saved_orientation = config.getdefault('internal',
+                                              'mod_screen_orientation', '')
+        saved_scale = config.getdefault('internal', 'mod_screen_scale', '')
+
+        first = True
+        first_btn = None
+        for device in sorted(screen.devices):
+            btn = DesignerActionProfileCheck(group='mod_screen_device',
+                            allow_no_selection=False, config_key=device)
+            btn.text = screen.devices[device][0]
+            btn.bind(on_active=self.on_module_settings)
+
+            if first:
+                btn.checkbox_active = first
+                first_btn = btn
+                first = False
+
+            if device == saved_device:
+                first_btn.checkbox_active = False
+                btn.checkbox_active = True
+            else:
+                btn.checkbox_active = False
+
+            devices.add_widget(btn)
+        for orientation in self.ids.module_screen_orientation.list_action_item:
+            if orientation.config_key == saved_orientation:
+                orientation.checkbox_active = True
+
+        for scale in self.ids.module_screen_scale.list_action_item:
+            if scale.config_key == saved_scale:
+                scale.checkbox_active = True
+
+    def on_run_press(self, *args):
+        '''Run button pressed. Analyze settings and dispatch ModulesContView
+                on run
+        '''
+        device = None
+        orientation = None
+        scale = None
+
+        for d in self.ids.module_screen_device.list_action_item:
+            if d.checkbox.active:
+                device = d.config_key
+                break
+
+        for o in self.ids.module_screen_orientation.list_action_item:
+            if o.checkbox.active:
+                orientation = o.config_key
+                break
+
+        for s in self.ids.module_screen_scale.list_action_item:
+            if s.checkbox.active:
+                scale = s.config_key
+                break
+
+        parameter = '%s,%s,scale=%s' % (device, orientation, scale)
+
+        self.dispatch('on_run', mod='screen', data=parameter)
+
+    def on_run(self, *args, **kwargs):
+        '''Event handler for on_run
+        '''
+        pass
+
+    def on_module_settings(self, instance, *args):
+        '''Event handle to save Screen Module settings when a different
+        option is selected
+        '''
+        if instance.checkbox.active:
+            self.designer.designer_settings.config_parser.set(
+                'internal',
+                instance.group,
+                instance.config_key
+            )
+            self.designer.designer_settings.config_parser.write()

--- a/designer/uix/modules_contview.py
+++ b/designer/uix/modules_contview.py
@@ -70,15 +70,15 @@ class ModScreenContView(ContextualActionView):
             btn.bind(on_active=self.on_module_settings)
 
             if first:
-                btn.checkbox_active = first
+                btn.checkbox_active = True
                 first_btn = btn
                 first = False
-
-            if device == saved_device:
-                first_btn.checkbox_active = False
-                btn.checkbox_active = True
             else:
-                btn.checkbox_active = False
+                if device == saved_device:
+                    first_btn.checkbox.active = False
+                    btn.checkbox_active = True
+                else:
+                    btn.checkbox_active = False
 
             devices.add_widget(btn)
         for orientation in self.ids.module_screen_orientation.list_action_item:


### PR DESCRIPTION
# PR Overview

I added support to some Kivy modules with KD. When running your project, you can select and use the following modules:

* touchring
* monitor
* screen - where you can set and emulate different screen sizes and dimensions
* inspector
* webdebugger

## Screenshots

Run menu:
![screenshot from 2015-08-22 13-47-54](https://cloud.githubusercontent.com/assets/4960137/9424903/78b86894-48d4-11e5-8563-1299de74aa9c.png)

Modules:

![screenshot from 2015-08-22 13-47-57](https://cloud.githubusercontent.com/assets/4960137/9424904/80427ef6-48d4-11e5-8a55-7e1de9bda698.png)

Screen module:

![screenshot from 2015-08-22 13-48-03](https://cloud.githubusercontent.com/assets/4960137/9424906/86b0f952-48d4-11e5-96ac-1eaa3b661b5f.png)


