### PR TITLE
clean bug report closes #136

### DIFF
--- a/designer/app.py
+++ b/designer/app.py
@@ -1602,13 +1602,20 @@ class Designer(FloatLayout):
 
 class DesignerException(ExceptionHandler):
 
+    raised_exception = False
+    '''Indicates if the BugReporter has already raised some exception
+    '''
+
     def handle_exception(self, inst):
+        if self.raised_exception:
+            return ExceptionManager.PASS
         App.get_running_app().stop()
         if isinstance(inst, KeyboardInterrupt):
             return ExceptionManager.PASS
         else:
             for child in Window.children:
                 Window.remove_widget(child)
+            self.raised_exception = True
             BugReporterApp(traceback.format_exc()).run()
             return ExceptionManager.PASS
 


### PR DESCRIPTION
If KD has a scheduled event, it can be dispatched when the BugReporter is open.
So KD tries to run some method, when actually is displaying a bug, generating a new bug :disappointed:

With this new patch, BugReporter ignores new exceptions, displaying only the original one.