### PR TITLE
create instance inside sandbox, better message in error console

### DIFF
--- a/designer/app.py
+++ b/designer/app.py
@@ -53,7 +53,7 @@ from designer.uix.designer_sandbox import DesignerSandbox
 from designer.project_settings import ProjectSettings
 from designer.designer_settings import DesignerSettings
 from designer.helper_functions import get_kivy_designer_dir, show_alert, \
-    ignore_proj_watcher, show_message, update_info
+    ignore_proj_watcher, show_message, update_info, show_error_console
 from designer.new_dialog import NewProjectDialog, NEW_PROJECTS
 from designer.eventviewer import EventViewer
 from designer.uix.designer_action_items import DesignerActionButton, \
@@ -1514,14 +1514,7 @@ class Designer(FloatLayout):
            on_getting_exception event. This function will add exception
            string in error_console.
         '''
-
-        s = traceback.format_list(traceback.extract_tb(
-            self.ui_creator.playground.sandbox.tb))
-        s = '\n'.join(s)
-        to_insert = "Exception:\n" + s + '\n' + \
-            "{!r}".format(self.ui_creator.playground.sandbox.exception)
-        text = self.ui_creator.error_console.text + to_insert + '\n\n'
-        self.ui_creator.error_console.text = text
+        show_error_console(traceback.format_exc(), append=False)
         if self.ui_creator.playground.sandbox.error_active:
             self.ui_creator.tab_pannel.switch_to(
                 self.ui_creator.tab_pannel.tab_list[0])

--- a/designer/helper_functions.py
+++ b/designer/helper_functions.py
@@ -151,6 +151,7 @@ def update_info(*args, **kwargs):
 
 def show_error_console(text, append=False):
     '''Shows a text on Error Console.
+    :param text: error message
     :param append appends the new text at the bottom of console
     '''
     d = get_designer()
@@ -185,15 +186,14 @@ def ignore_proj_watcher(f):
     return wrapper
 
 
-def get_app_widget(target):
+def get_app_widget(target, **default_args):
     '''Creates a widget instance by it's name and module
     '''
+    d = get_designer()
     if target.is_dynamic:
         name = target.name.split('@')[0]
-        try:
-            return Factory.get(name)()
-        except:
-            return None
+        with d.ui_creator.playground.sandbox:
+            return Factory.get(name)(**default_args)
     elif target.is_root:
         return target.instance
     else:
@@ -201,6 +201,7 @@ def get_app_widget(target):
                                      inspect.isclass)
         for klass_name, klass in classes:
             if issubclass(klass, Widget) and klass_name == target.name:
-                return klass()
+                with d.ui_creator.playground.sandbox:
+                    return klass(**default_args)
 
         return None

--- a/designer/project_manager.py
+++ b/designer/project_manager.py
@@ -328,8 +328,7 @@ class Project(EventDispatcher):
         root = None
         try:
             root = Builder.load_string(src, filename=os.path.basename(path))
-        except (SyntaxError, AttributeError, BuilderException,
-                ParserException, FactoryException) as e:
+        except Exception as e:
             self._errors.append(str(e))
             d = get_designer()
             d.ui_creator.kv_code_input.have_error = True


### PR DESCRIPTION
* The project manager allows to easily map project widgets. The function (get_widget) was re-implemented.
* Displaying a formatted exception on error console
* instancing widgets with sandbox