### PR TITLE
not add widget to itself on tabbed panel closes #181

### DIFF
--- a/designer/playground.py
+++ b/designer/playground.py
@@ -966,7 +966,7 @@ class Playground(ScatterPlane):
                     if isinstance(child, TabbedPanel):
                         if child.current_tab:
                             _item = self.find_target(
-                                x, y, child.current_tab.content)
+                                x, y, child.current_tab.content, widget)
                             return _item
 
                     else:


### PR DESCRIPTION
It' necessary to check if the tabbed content is not the widget being added itself.