### PR TITLE
fixing project template bug

### DIFF
--- a/designer/new_dialog.py
+++ b/designer/new_dialog.py
@@ -2,7 +2,7 @@ import designer
 
 from kivy.uix.boxlayout import BoxLayout
 from kivy.uix.listview import ListView
-from kivy.properties import ObjectProperty
+from kivy.properties import ObjectProperty, NumericProperty
 from kivy.adapters.listadapter import ListAdapter
 from kivy.uix.image import Image
 from os.path import join, dirname, split
@@ -65,6 +65,12 @@ class NewProjectDialog(BoxLayout):
        :data:`list_parent` is a :class:`~kivy.properties.ObjectProperty`
     '''
 
+    prev_selection = NumericProperty(0)
+    '''to memorize the previous selection.
+       :attr:`prev_selection` is a :class:
+       `~kivy.properties.NumericProperty`, defaults to (0).
+    '''
+
     __events__ = ('on_select', 'on_cancel')
 
     def __init__(self, **kwargs):
@@ -75,12 +81,21 @@ class NewProjectDialog(BoxLayout):
                                    data=item_strings,
                                    selection_mode='single',
                                    allow_empty_selection=False)
+        self.adapter.check_for_empty_selection = self.check_for_empty_selection
         self.adapter.bind(on_selection_change=self.on_adapter_selection_change)
         self.listview = ListView(adapter=self.adapter)
         self.listview.size_hint = (0.5, 1)
         self.listview.pos_hint = {'top': 1}
         self.list_parent.add_widget(self.listview, 1)
         self.on_adapter_selection_change(self.adapter)
+
+    def check_for_empty_selection(self, *args):
+        if not self.adapter.allow_empty_selection:
+            if len(self.adapter.selection) == 0:
+                # Select the first item if we have it.
+                v = self.adapter.get_view(self.prev_selection)
+                if v is not None:
+                    self.adapter.handle_selection(v)
 
     def on_adapter_selection_change(self, adapter):
         '''Event handler for 'on_selection_change' event of adapter.
@@ -94,6 +109,15 @@ class NewProjectDialog(BoxLayout):
         parent.remove_widget(self.image)
         self.image = Image(source=image_source)
         parent.add_widget(self.image)
+        self.prev_selection = adapter.data.index(adapter.selection[0].text)
+
+    def on_touch_down(self, touch):
+        '''Used to determine where touch is down and to detect double
+           tap.
+        '''
+        if touch.is_double_tap:
+            self.dispatch('on_select')
+        return super(NewProjectDialog, self).on_touch_down(touch)
 
     def on_select(self, *args):
         '''Default Event Handler for 'on_select' event


### PR DESCRIPTION
**Bug**
In the New Project dialog, select a template, and then click on the template name again. It’ll select the ActionBar template.
**Status**
Fixed.
**Enhancement**
Double_tap on the template name to open it.