### PR TITLE
Stop requiring specific kivy version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,7 @@ setup(
                                'tools/ssh-agent/*']},
     license='MIT',
     install_requires=[
-        'kivy >= 1.9.1',
+        'kivy',
         'pygments >= 2.1',
         'docutils >= 0.12',
         'watchdog >= 0.8',


### PR DESCRIPTION
Breaks stuff for 1.9.1 as there's no wheel for python 3.5 and reinstalls stable wheel (with compilation if 3.5) even when master is available, because for some reason it can't compare the versions. Might be related to https://github.com/kivy/kivy/issues/4861