### PR TITLE
Update cython version in .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ install:
     sudo apt-get install python-dev libsmpeg-dev libswscale-dev libavformat-dev libavcodec-dev libjpeg-dev libtiff4-dev libX11-dev libmtdev-dev;
     sudo apt-get install python-setuptools build-essential libgl1-mesa-dev libgles2-mesa-dev;
     sudo apt-get install xvfb pulseaudio;
-    pip install --upgrade Cython==0.21.2 pillow nose coveralls;
+    pip install --upgrade Cython==0.25.2 pillow nose coveralls;
     pip install -r requirements.txt;
     garden install filebrowser;
 


### PR DESCRIPTION
Update cython in .travis.yml to support new release of kivy.

Previous Error:
```
Detected Cython version 0.21.2
      This version of Cython is not compatible with Kivy. Please upgrade to
      at least version 0.23, preferably the newest supported version 0.25.2.
    
      If your platform provides a Cython package, make sure you have upgraded
      to the newest version. If the newest version available is still too low,
      please remove it and install the newest supported Cython via pip:
    
        pip install -I Cython==0.25.2
    
    Cython is missing, it's required for compiling kivy !
    
    
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/tmp/pip-build-Tw8i5S/kivy/setup.py", line 227, in <module>
        raise ImportError('Incompatible Cython Version')
    ImportError: Incompatible Cython Version
```
