### PR TITLE
Added `utf-8` encoding for IO operation on buildozer.spec

### DIFF
--- a/designer/app.py
+++ b/designer/app.py
@@ -786,9 +786,11 @@ class Designer(FloatLayout):
         shutil.copy(os.path.join(templates_dir, kv_file),
                     os.path.join(new_proj_dir, "main.kv"))
 
-        buildozer = io.open(os.path.join(new_proj_dir, 'buildozer.spec'), 'w')
+        buildozer = io.open(os.path.join(new_proj_dir, 'buildozer.spec'), 'w',
+                            encoding='utf-8')
 
-        for line in io.open(os.path.join(templates_dir, 'default.spec'), 'r'):
+        for line in io.open(os.path.join(templates_dir, 'default.spec'), 'r',
+                            encoding='utf-8'):
             line = line.replace('$app_name', app_name)
             line = line.replace('$package_name', package_name)
             line = line.replace('$package_domain', package_domain)


### PR DESCRIPTION
In continuation of #315, fixes IO error at creating of new project

## Traceback

```
Traceback (most recent call last):
  File "/Users/manthansharma/virtualenvs/kivy-designer/lib/python2.7/site-packages/kivy/core/window/window_sdl2.py", line 619, in mainloop
    self._mainloop()
  File "/Users/manthansharma/virtualenvs/kivy-designer/lib/python2.7/site-packages/kivy/core/window/window_sdl2.py", line 362, in _mainloop
    EventLoop.idle()
  File "/Users/manthansharma/virtualenvs/kivy-designer/lib/python2.7/site-packages/kivy/base.py", line 330, in idle
    self.dispatch_input()
  File "/Users/manthansharma/virtualenvs/kivy-designer/lib/python2.7/site-packages/kivy/base.py", line 315, in dispatch_input
    post_dispatch_input(*pop(0))
  File "/Users/manthansharma/virtualenvs/kivy-designer/lib/python2.7/site-packages/kivy/base.py", line 221, in post_dispatch_input
    listener.dispatch('on_motion', etype, me)
  File "kivy/_event.pyx", line 718, in kivy._event.EventDispatcher.dispatch (/private/var/folders/6w/72jhjll92ns95l612vfg4fgc0000gn/T/pip-build-QbKsKu/kivy/kivy/_event.c:8164)
  File "/Users/manthansharma/virtualenvs/kivy-designer/lib/python2.7/site-packages/kivy/core/window/__init__.py", line 1030, in on_motion
    self.dispatch('on_touch_down', me)
  File "kivy/_event.pyx", line 718, in kivy._event.EventDispatcher.dispatch (/private/var/folders/6w/72jhjll92ns95l612vfg4fgc0000gn/T/pip-build-QbKsKu/kivy/kivy/_event.c:8164)
  File "/Users/manthansharma/virtualenvs/kivy-designer/lib/python2.7/site-packages/kivy/core/window/__init__.py", line 1046, in on_touch_down
    if w.dispatch('on_touch_down', touch):
  File "kivy/_event.pyx", line 718, in kivy._event.EventDispatcher.dispatch (/private/var/folders/6w/72jhjll92ns95l612vfg4fgc0000gn/T/pip-build-QbKsKu/kivy/kivy/_event.c:8164)
  File "/Users/manthansharma/virtualenvs/kivy-designer/lib/python2.7/site-packages/kivy/uix/popup.py", line 201, in on_touch_down
    return super(Popup, self).on_touch_down(touch)
  File "/Users/manthansharma/virtualenvs/kivy-designer/lib/python2.7/site-packages/kivy/uix/modalview.py", line 242, in on_touch_down
    super(ModalView, self).on_touch_down(touch)
  File "/Users/manthansharma/virtualenvs/kivy-designer/lib/python2.7/site-packages/kivy/uix/widget.py", line 432, in on_touch_down
    if child.dispatch('on_touch_down', touch):
  File "kivy/_event.pyx", line 718, in kivy._event.EventDispatcher.dispatch (/private/var/folders/6w/72jhjll92ns95l612vfg4fgc0000gn/T/pip-build-QbKsKu/kivy/kivy/_event.c:8164)
  File "/Users/manthansharma/virtualenvs/kivy-designer/lib/python2.7/site-packages/kivy/uix/widget.py", line 432, in on_touch_down
    if child.dispatch('on_touch_down', touch):
  File "kivy/_event.pyx", line 718, in kivy._event.EventDispatcher.dispatch (/private/var/folders/6w/72jhjll92ns95l612vfg4fgc0000gn/T/pip-build-QbKsKu/kivy/kivy/_event.c:8164)
  File "/Users/manthansharma/virtualenvs/kivy-designer/lib/python2.7/site-packages/kivy/uix/widget.py", line 432, in on_touch_down
    if child.dispatch('on_touch_down', touch):
  File "kivy/_event.pyx", line 718, in kivy._event.EventDispatcher.dispatch (/private/var/folders/6w/72jhjll92ns95l612vfg4fgc0000gn/T/pip-build-QbKsKu/kivy/kivy/_event.c:8164)
  File "/Users/manthansharma/virtualenvs/kivy-designer/lib/python2.7/site-packages/kivy/uix/widget.py", line 432, in on_touch_down
    if child.dispatch('on_touch_down', touch):
  File "kivy/_event.pyx", line 718, in kivy._event.EventDispatcher.dispatch (/private/var/folders/6w/72jhjll92ns95l612vfg4fgc0000gn/T/pip-build-QbKsKu/kivy/kivy/_event.c:8164)
  File "/Users/manthansharma/virtualenvs/kivy-designer/lib/python2.7/site-packages/kivy/uix/widget.py", line 432, in on_touch_down
    if child.dispatch('on_touch_down', touch):
  File "kivy/_event.pyx", line 718, in kivy._event.EventDispatcher.dispatch (/private/var/folders/6w/72jhjll92ns95l612vfg4fgc0000gn/T/pip-build-QbKsKu/kivy/kivy/_event.c:8164)
  File "/Users/manthansharma/virtualenvs/kivy-designer/lib/python2.7/site-packages/kivy/uix/widget.py", line 432, in on_touch_down
    if child.dispatch('on_touch_down', touch):
  File "kivy/_event.pyx", line 718, in kivy._event.EventDispatcher.dispatch (/private/var/folders/6w/72jhjll92ns95l612vfg4fgc0000gn/T/pip-build-QbKsKu/kivy/kivy/_event.c:8164)
  File "/Users/manthansharma/virtualenvs/kivy-designer/lib/python2.7/site-packages/kivy/uix/behaviors/button.py", line 110, in on_touch_down
    self.dispatch('on_press')
  File "kivy/_event.pyx", line 714, in kivy._event.EventDispatcher.dispatch (/private/var/folders/6w/72jhjll92ns95l612vfg4fgc0000gn/T/pip-build-QbKsKu/kivy/kivy/_event.c:8119)
  File "kivy/_event.pyx", line 1224, in kivy._event.EventObservers.dispatch (/private/var/folders/6w/72jhjll92ns95l612vfg4fgc0000gn/T/pip-build-QbKsKu/kivy/kivy/_event.c:14008)
  File "kivy/_event.pyx", line 1148, in kivy._event.EventObservers._dispatch (/private/var/folders/6w/72jhjll92ns95l612vfg4fgc0000gn/T/pip-build-QbKsKu/kivy/kivy/_event.c:13537)
  File "kivy/_event.pyx", line 714, in kivy._event.EventDispatcher.dispatch (/private/var/folders/6w/72jhjll92ns95l612vfg4fgc0000gn/T/pip-build-QbKsKu/kivy/kivy/_event.c:8119)
  File "kivy/_event.pyx", line 1224, in kivy._event.EventObservers.dispatch (/private/var/folders/6w/72jhjll92ns95l612vfg4fgc0000gn/T/pip-build-QbKsKu/kivy/kivy/_event.c:14008)
  File "kivy/_event.pyx", line 1148, in kivy._event.EventObservers._dispatch (/private/var/folders/6w/72jhjll92ns95l612vfg4fgc0000gn/T/pip-build-QbKsKu/kivy/kivy/_event.c:13537)
  File "/Users/manthansharma/Projects/PycharmProjects/kivy-designer/designer/utils/utils.py", line 198, in wrapper
    f(*args, **kwargs)
  File "/Users/manthansharma/Projects/PycharmProjects/kivy-designer/designer/app.py", line 791, in _perform_new
    for line in io.open(os.path.join(templates_dir, 'default.spec'), 'r'):
  File "/Users/manthansharma/virtualenvs/kivy-designer/lib/python2.7/encodings/ascii.py", line 26, in decode
    return codecs.ascii_decode(input, self.errors)[0]
UnicodeDecodeError: 'ascii' codec can't decode byte 0xc2 in position 1681: ordinal not in range(128)
```

End of Traceback